### PR TITLE
fix license link not found issue in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LeetCode Solutions Archive
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](/LICENSE)
 
 A **fully automated archive of LeetCode problems** with complete solutions, multiple approaches, and time/space complexities. This repository provides a **static website** for browsing, searching, and filtering problems using Vanilla JS, and it is designed to be **scalable and contributor-friendly**.
 
@@ -177,4 +177,4 @@ This script generates the `data/` folder used by the frontend:
 
 ## 📄 License
 
-This project is licensed under the **MIT License** — see [LICENSE.md](LICENSE.md). 
+This project is licensed under the **MIT License** — see [LICENSE](/LICENSE). 


### PR DESCRIPTION
### What
- fixed the license.md page not found issue in README.m

### Why
- to provide correct link to the license page

### How
- updated the hyperlink pointing to the correct path